### PR TITLE
Composer require GTE PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - '7.2'
+  - '7.3'
 
 install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.1",
-        "psr/http-factory": "^1.0.1"
+        "psr/http-factory": "^1.0.1",
+        "php": ">=7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",
@@ -23,7 +24,7 @@
     "autoload": {
         "psr-4": {
             "Anfly0\\Middleware\\GitHub\\": "src"
-    }
+        }
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
PHPUnit 8 requires PHP 7.2 or higher. As you can only test against 7.2 or higher, my recommendation would be to define this as an explicit minimum requirement.

I also updated travis to test against 7.3 as well.